### PR TITLE
Allow sameJSONAs to compare JSON strings & JSON numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
-			<version>1.2.2-SNAPSHOT</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
-			<version>1.1.1</version>
+			<version>1.2.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/src/test/java/uk/co/datumedge/hamcrest/json/SameJSONAsTest.java
+++ b/src/test/java/uk/co/datumedge/hamcrest/json/SameJSONAsTest.java
@@ -155,6 +155,14 @@ public class SameJSONAsTest {
 		assertThat("{\"foo\": 5}", not(sameJSONAs("[5, 2]")));
 	}
 
+  @Test public void stringMatches() {
+    assertThat("\"Joe\"", is(sameJSONAs("\"Joe\"")));
+  }
+
+  @Test public void numberMatches() {
+    assertThat("-12.34e-2", is(sameJSONAs("-12.34e-2")));
+  }
+
 	private void allowingJSONComparatorToThrowJSONException() throws JSONException {
 		context.checking(new Expectations() {{
 			allowing(jsonComparator).compare(expected, actual); will(throwException(new JSONException(EXCEPTION_MESSAGE)));


### PR DESCRIPTION
Updated jsonassert dependency to 1.2.2 which adds support for comparing JSON strings & JSON numbers.
Added tests to verify that sameJSONAs handles JSON strings & JSON numbers.
